### PR TITLE
feat: service status chip

### DIFF
--- a/components/home/hero-content.tsx
+++ b/components/home/hero-content.tsx
@@ -4,11 +4,18 @@ export default function HomeHeroContent() {
   return (
     <main className="absolute inset-0 z-20 flex items-center justify-center">
       <div className="max-w-4xl px-6 text-center">
-        <div className="relative mb-8 inline-flex items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 backdrop-blur-sm">
-          <span className="text-primary text-sm font-medium">
-            ✨ Nexora DevLabs
-          </span>
+        <a href="https://status.nexodev.io" target="_blank" rel="noopener noreferrer">
+        <div className="relative mb-8 inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 backdrop-blur-sm">
+          <iframe 
+            src="https://status.nexodev.io/badge?theme=dark" 
+            width="190" 
+            height="30" 
+            style={{ colorScheme: 'normal', pointerEvents: 'none' }}
+            title="Nexora DevLabs Service Status"
+            className="rounded-full"
+          />
         </div>
+        </a>
 
         <h1 className="font-heading mb-6 text-5xl font-bold leading-tight text-white md:text-7xl">
           <span className="text-primary">Simplify.</span> Build.{" "}


### PR DESCRIPTION
This pull request updates the service status display in the `HomeHeroContent` component to provide a more dynamic and informative experience for users. Instead of showing a static label, it now embeds a live status badge via an iframe, which links directly to the Nexora DevLabs status page.

**User interface improvement:**

* Replaced the static "✨ Nexora DevLabs" label with an embedded iframe badge showing live service status, wrapped in a link to the external status page. This makes the status more visible and interactive for users. (`components/home/hero-content.tsx`, [components/home/hero-content.tsxL7-R18](diffhunk://#diff-75f3704a4e91a9ef363475b0c571c4a35f04a6ea788939f2b397950d6dc34b77L7-R18))